### PR TITLE
fix: escape HYAS Protect widget values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) Hyas, 2022-2025
+   Copyright (c) Hyas, 2022-2026
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: HYAS Protect
-Copyright (c) Hyas, 2022-2025
+Copyright (c) Hyas, 2022-2026

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # HYAS Protect
 
-Publisher: HYAS \
-Connector Version: 1.2.1 \
-Product Vendor: HYAS \
-Product Name: HYAS Protect \
+Publisher: HYAS <br>
+Connector Version: 1.2.1 <br>
+Product Vendor: HYAS <br>
+Product Name: HYAS Protect <br>
 Minimum Product Version: 6.1.1
 
 This app implements investigative actions that return HYAS Protect Verdict for the given Indicators
@@ -28,18 +28,18 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[ip verdict](#action-ip-verdict) - Perform this action to get the Hyas Verdict for IP \
-[domain verdict](#action-domain-verdict) - Perform this action to get the Hyas Verdict for Domain \
-[fqdn verdict](#action-fqdn-verdict) - Perform this action to get the Hyas Verdict for FQDN \
-[nameserver verdict](#action-nameserver-verdict) - Perform this action to get the Hyas Verdict for Nameserver \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[ip verdict](#action-ip-verdict) - Perform this action to get the Hyas Verdict for IP <br>
+[domain verdict](#action-domain-verdict) - Perform this action to get the Hyas Verdict for Domain <br>
+[fqdn verdict](#action-fqdn-verdict) - Perform this action to get the Hyas Verdict for FQDN <br>
+[nameserver verdict](#action-nameserver-verdict) - Perform this action to get the Hyas Verdict for Nameserver <br>
 [block dns](#action-block-dns) - Perform this action to add domain to deny list
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -54,7 +54,7 @@ No Output
 
 Perform this action to get the Hyas Verdict for IP
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -79,7 +79,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Perform this action to get the Hyas Verdict for Domain
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -104,7 +104,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Perform this action to get the Hyas Verdict for FQDN
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -129,7 +129,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Perform this action to get the Hyas Verdict for Nameserver
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -154,7 +154,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 Perform this action to add domain to deny list
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -178,7 +178,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) Hyas, 2022-2025
+# Copyright (c) Hyas, 2022-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hyasprotect.json
+++ b/hyasprotect.json
@@ -7,10 +7,10 @@
     "logo": "logo_hyasprotect.svg",
     "logo_dark": "logo_hyasprotect_dark.svg",
     "product_name": "HYAS Protect",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "product_version_regex": ".*",
     "publisher": "HYAS",
-    "license": "Copyright (c) Hyas, 2022-2025",
+    "license": "Copyright (c) Hyas, 2022-2026",
     "app_version": "1.2.1",
     "utctime_updated": "2025-04-28T19:55:23.429505Z",
     "package_name": "phantom_hyasprotect",
@@ -438,5 +438,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/hyasprotect_connector.py
+++ b/hyasprotect_connector.py
@@ -5,7 +5,7 @@
 
 # File: hyasprotect_connector.py
 #
-# Copyright (c) Hyas, 2022-2025
+# Copyright (c) Hyas, 2022-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hyasprotect_consts.py
+++ b/hyasprotect_consts.py
@@ -1,6 +1,6 @@
 # File: hyasprotect_consts.py
 #
-# Copyright (c) Hyas, 2022-2025
+# Copyright (c) Hyas, 2022-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hyasprotect_display_view.html
+++ b/hyasprotect_display_view.html
@@ -15,7 +15,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: hyasprotect_display_view.html
-  Copyright (c) Hyas, 2022-2025
+  Copyright (c) Hyas, 2022-2026
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

--- a/hyasprotect_display_view.html
+++ b/hyasprotect_display_view.html
@@ -58,7 +58,7 @@
             <td>IP</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['ip'],'value': '{{ result.param.ip }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['ip'],'value': '{{ result.param.ip|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.ip }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -73,7 +73,7 @@
             <td>Domain</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['domain'],'value': '{{ result.param.domain }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['domain'],'value': '{{ result.param.domain|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.domain }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -88,7 +88,7 @@
             <td>FQDN</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['fqdn'],'value': '{{ result.param.fqdn }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['fqdn'],'value': '{{ result.param.fqdn|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.fqdn }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>
@@ -103,7 +103,7 @@
             <td>Nameserver</td>
             <td>
               <a href="javascript:;"
-                 onclick="context_menu(this, [{'contains': ['nameserver'],'value': '{{ result.param.nameserver }}' }], 0, {{ container.id }}, null, false);">
+                 onclick="context_menu(this, [{'contains': ['nameserver'],'value': '{{ result.param.nameserver|escapejs }}' }], 0, {{ container.id }}, null, false);">
                 {{ result.param.nameserver }}
                 &nbsp;
                 <span class="fa fa-caret-down" style="font-size: smaller;"></span>

--- a/hyasprotect_view.py
+++ b/hyasprotect_view.py
@@ -1,6 +1,6 @@
 # File: hyasprotect_view.py
 #
-# Copyright (c) Hyas, 2022-2025
+# Copyright (c) Hyas, 2022-2026
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Updated connector development tooling and supported Python versions.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * - Updated connector development tooling and supported Python versions.
+* Escaped every caller-controlled value embedded in widget JavaScript handlers.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 
-* - Updated connector development tooling and supported Python versions.
+* Updated connector development tooling and supported Python versions.
 * Escaped every caller-controlled value embedded in widget JavaScript handlers.


### PR DESCRIPTION
## Summary

- apply Django escapejs to every caller-controlled value embedded in widget JavaScript handlers
- refresh the connector tooling baseline to dev-cicd-tools v2.2.4
- declare supported Python 3.9 and 3.13 runtimes

## Tracking

- PAPP-38203
- PSAAS-30815
- Parent epic: ESPM-5228

## Validation

- local pre-commit: passed
- hosted pre-commit and compile: pending

## AI assistance

- [x] This pull request was created entirely with AI assistance.

Written by Codex.